### PR TITLE
Make options arg optional.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -13,7 +13,7 @@ declare module "fdir" {
    * @param directoryPath Path to the directory
    * @param options Options
    */
-  function sync(directoryPath: String, options: Options): Array<String>;
+  function sync(directoryPath: String, options?: Options): Array<String>;
 
   /**
    * Asynchronously walks the directory recursively
@@ -22,7 +22,7 @@ declare module "fdir" {
    */
   function async(
     directoryPath: String,
-    options: Options
+    options?: Options
   ): Promise<Array<String>>;
 
   export { sync, async };


### PR DESCRIPTION
Since both functions use `options = {}` there's no need to force the options argument.

This now allows the following.
```ts
import * as fdir from 'fdir';

fdir.async('/').then(files => {
    console.log(files);
});
```

Where as before you'd need to pass an empty second param.
```ts
import * as fdir from 'fdir';

fdir.async('/', {}).then(files => {
    console.log(files);
});
```