### PR TITLE
Remove --save

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ fdir.withDirs()
 You can install using `npm`:
 
 ```sh
-$ npm i --save fdir
+$ npm i fdir
 ```
 
 or Yarn:


### PR DESCRIPTION
The flag is made unnecessary long time ago.

`npm i` saves packages as dependencies by default