### PR TITLE
feat: add support for multiple filters

### DIFF
--- a/__tests__/fdir.test.js
+++ b/__tests__/fdir.test.js
@@ -95,6 +95,18 @@ describe.each(["withPromise", "sync"])("fdir %s", (type) => {
     expect(files.every((file) => file.includes(".git"))).toBe(true);
   });
 
+  test("crawl all files with multifilter", async () => {
+    const api = new fdir()
+      .withBasePath()
+      .filter((file) => file.includes(".git"))
+      .filter((file) => file.includes(".js"))
+      .crawl("./");
+    const files = await api[type]();
+    expect(
+      files.every((file) => file.includes(".git") || file.includes(".js"))
+    ).toBe(true);
+  });
+
   test("crawl all files in a directory (with base path)", async () => {
     const api = new fdir().withBasePath().crawl("./");
     const files = await api[type]();

--- a/documentation.md
+++ b/documentation.md
@@ -205,13 +205,15 @@ const crawler = new fdir().glob("./**/*.js", "./**/*.md");
 
 Applies a filter to all files and only adds those that satisfy it.
 
-> _Currently, you can apply only one filter per crawler. This might change._
+> _You can now apply multiple filters._
 
 **Usage**
 
 ```js
-// only get hidden files
-const crawler = new fdir().filter((path) => path.startsWith("."));
+// only get hidden & .js files
+const crawler = new fdir()
+  .filter((path) => path.startsWith("."))
+  .filter((path) => path.endsWith(".js"));
 ```
 
 ### `exclude(Function)`
@@ -325,7 +327,7 @@ type Options = {
   suppressErrors?: boolean;
   group?: boolean;
   onlyCounts?: boolean;
-  filter?: FilterFn;
+  filters?: FilterFn[];
   exclude?: ExcludeFn;
 };
 ```

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare module "fdir" {
     suppressErrors?: boolean;
     group?: boolean;
     onlyCounts?: boolean;
-    filter?: FilterFn;
+    filters?: FilterFn[];
     exclude?: ExcludeFn;
   };
 

--- a/src/api/fns.js
+++ b/src/api/fns.js
@@ -9,16 +9,18 @@ module.exports.getArrayGroup = function() {
 };
 
 /** PUSH FILE */
-module.exports.pushFileFilterAndCount = function(filter) {
+module.exports.pushFileFilterAndCount = function(filters) {
   return function(filename, _files, _dir, state) {
-    if (filter(filename)) state.counts.files++;
+    if (filters.some((f) => f(filename))) state.counts.files++;
   };
 };
-module.exports.pushFileFilter = function(filter) {
+
+module.exports.pushFileFilter = function(filters) {
   return function(filename, files) {
-    if (filter(filename)) files.push(filename);
+    if (filters.some((f) => f(filename))) files.push(filename);
   };
 };
+
 module.exports.pushFileCount = function(_filename, _files, _dir, state) {
   state.counts.files++;
 };

--- a/src/api/shared.js
+++ b/src/api/shared.js
@@ -59,7 +59,7 @@ function walkSingleDir(
 
 function buildFunctions(options, isSync) {
   const {
-    filterFn,
+    filters,
     onlyCountsVar,
     includeBasePath,
     includeDirs,
@@ -68,10 +68,10 @@ function buildFunctions(options, isSync) {
   } = options;
 
   // build function for adding paths to array
-  if (filterFn && onlyCountsVar) {
-    pushFile = fns.pushFileFilterAndCount(filterFn);
-  } else if (filterFn) {
-    pushFile = fns.pushFileFilter(filterFn);
+  if (filters.length && onlyCountsVar) {
+    pushFile = fns.pushFileFilterAndCount(filters);
+  } else if (filters.length) {
+    pushFile = fns.pushFileFilter(filters);
   } else if (onlyCountsVar) {
     pushFile = fns.pushFileCount;
   } else {

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -11,6 +11,7 @@ try {
 function Builder() {
   this.maxDepth = Infinity;
   this.suppressErrors = true;
+  this.filters = [];
 }
 
 Builder.prototype.crawl = function(path) {
@@ -22,7 +23,7 @@ Builder.prototype.crawlWithOptions = function(path, options) {
   options.groupVar = options.group;
   options.onlyCountsVar = options.onlyCounts;
   options.excludeFn = options.exclude;
-  options.filterFn = options.filter;
+  options.filters = options.filters || [];
   return new APIBuilder(path, options);
 };
 
@@ -63,7 +64,7 @@ Builder.prototype.normalize = function() {
 };
 
 Builder.prototype.filter = function(filterFn) {
-  this.filterFn = filterFn;
+  this.filters.push(filterFn);
   return this;
 };
 
@@ -75,9 +76,7 @@ Builder.prototype.glob = function(...patterns) {
     );
   }
   const isMatch = pm(patterns);
-  this.filterFn = (path) => {
-    return isMatch(path, patterns);
-  };
+  this.filters.push((path) => isMatch(path, patterns));
   return this;
 };
 


### PR DESCRIPTION
It is now possible to add multiple filters like:

```js
new fdir().filter(p => p.endsWith(".js")).filter(p => p.startsWith(".nim"))
```
Obviously, you can also do that in a single filter but I think it allows for better readability. The performance hit is also negligible.