### PR TITLE
Fix #42, #46 and #47

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -218,7 +218,9 @@ const crawler = new fdir()
 
 ### `exclude(Function)`
 
-Applies an exclusion filter to all directories and only crawls those that do not satisfy the condition.
+Applies an exclusion filter to all directories and only crawls those that do not satisfy the condition. Useful for speeding up crawling if you know you can ignore some directories.
+
+The function receives two parameters: the first is the name of the directory, and the second is the absolute path to it.
 
 > _Currently, you can apply only one exclusion filter per crawler. This might change._
 
@@ -226,7 +228,7 @@ Applies an exclusion filter to all directories and only crawls those that do not
 
 ```js
 // do not crawl into hidden directories
-const crawler = new fdir().exclude((dir) => dir.startsWith("."));
+const crawler = new fdir().exclude((dirName, dirPath) => dirName.startsWith("."));
 ```
 
 ### `crawl(string)`

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,7 +4,7 @@ declare module "fdir" {
   export type PathsOutput = string[];
 
   type FilterFn = (filePath: string) => boolean;
-  type ExcludeFn = (dirPath: string) => boolean;
+  type ExcludeFn = (dirName: string, dirPath: string) => boolean;
   type Callback = (error: Error, output: Output) => void;
 
   type Group = { dir: string; files: string[] };

--- a/src/api/fns.js
+++ b/src/api/fns.js
@@ -44,7 +44,7 @@ module.exports.joinPath = function(filename) {
 /** WALK DIR */
 module.exports.walkDirExclude = function(exclude) {
   return function(walk, state, path, dir, currentDepth, callback) {
-    if (!exclude(dir)) {
+    if (!exclude(dir, path)) {
       module.exports.walkDir(walk, state, path, dir, currentDepth, callback);
     }
   };

--- a/src/api/shared.js
+++ b/src/api/shared.js
@@ -3,112 +3,119 @@ const { cleanPath } = require("../utils");
 const fns = require("./fns");
 const readdirOpts = { withFileTypes: true };
 
-function init(dir, options, callback, isSync) {
-  if (options.resolvePaths) dir = pathResolve(dir);
-  if (options.normalizePath) dir = cleanPath(dir);
+module.exports = { makeWalkerFunctions, readdirOpts };
 
-  /* We use a local state object instead of direct global variables so that each function
-   * execution is independent of each other.
-   */
-  const state = {
-    // Perf: we explicitly tell the compiler to optimize for String arrays
-    paths: [""].slice(0, 0),
-    queue: 0,
-    counts: { files: 0, dirs: 0 },
-    options,
-    callback,
-  };
+// We cannot simply export `init` and `walkSingleDir` directly. We need to rebuild them on every call.
+// Otherwise, the functions setup by `buildFunctions` can be overwritten if a new concurrent async
+// call is performed while walking is still happening from another call.
+function makeWalkerFunctions() {
+  function init(dir, options, callback, isSync) {
+    if (options.resolvePaths) dir = pathResolve(dir);
+    if (options.normalizePath) dir = cleanPath(dir);
 
-  /*
-   * Perf: We conditionally change functions according to options. This gives a slight
-   * performance boost. Since these functions are so small, they are automatically inlined
-   * by the engine so there's no function call overhead (in most cases).
-   */
-  buildFunctions(options, isSync);
+    /* We use a local state object instead of direct global variables so that each function
+    * execution is independent of each other.
+    */
+    const state = {
+      // Perf: we explicitly tell the compiler to optimize for String arrays
+      paths: [""].slice(0, 0),
+      queue: 0,
+      counts: { files: 0, dirs: 0 },
+      options,
+      callback,
+    };
 
-  return { state, callbackInvoker, dir };
-}
+    /*
+    * Perf: We conditionally change functions according to options. This gives a slight
+    * performance boost. Since these functions are so small, they are automatically inlined
+    * by the engine so there's no function call overhead (in most cases).
+    */
+    buildFunctions(options, isSync);
 
-function walkSingleDir(walk, state, dir, dirents, currentDepth, callback) {
-  pushDir(dir, state.paths);
-  // in cases where we have / as path
-  if (dir === sep) dir = "";
+    return { state, callbackInvoker, dir };
+  }
 
-  const files = getArray(state);
+  function walkSingleDir(walk, state, dir, dirents, currentDepth, callback) {
+    pushDir(dir, state.paths);
+    // in cases where we have / as path
+    if (dir === sep) dir = "";
 
-  for (var i = 0; i < dirents.length; ++i) {
-    const dirent = dirents[i];
+    const files = getArray(state);
 
-    if (dirent.isFile()) {
-      const filename = joinPath(dirent.name, dir);
-      pushFile(filename, files, dir, state);
-    } else if (dirent.isDirectory()) {
-      let dirPath = `${dir}${sep}${dirent.name}`;
-      walkDir(walk, state, dirPath, dirent.name, currentDepth - 1, callback);
+    for (var i = 0; i < dirents.length; ++i) {
+      const dirent = dirents[i];
+
+      if (dirent.isFile()) {
+        const filename = joinPath(dirent.name, dir);
+        pushFile(filename, files, dir, state);
+      } else if (dirent.isDirectory()) {
+        let dirPath = `${dir}${sep}${dirent.name}`;
+        walkDir(walk, state, dirPath, dirent.name, currentDepth - 1, callback);
+      }
+    }
+
+    groupFiles(dir, files, state);
+  }
+
+  function buildFunctions(options, isSync) {
+    const {
+      filters,
+      onlyCountsVar,
+      includeBasePath,
+      includeDirs,
+      groupVar,
+      excludeFn,
+    } = options;
+
+    buildPushFile(filters, onlyCountsVar);
+
+    pushDir = includeDirs ? fns.pushDir : fns.empty;
+
+    // build function for joining paths
+    joinPath = includeBasePath ? fns.joinPathWithBasePath : fns.joinPath;
+
+    // build recursive walk directory function
+    walkDir = excludeFn ? fns.walkDirExclude(excludeFn) : fns.walkDir;
+
+    // build groupFiles function for grouping files
+    groupFiles = groupVar ? fns.groupFiles : fns.empty;
+    getArray = groupVar ? fns.getArrayGroup : fns.getArray;
+
+    buildCallbackInvoker(onlyCountsVar, isSync);
+  }
+
+  function buildPushFile(filters, onlyCountsVar) {
+    if (filters.length && onlyCountsVar) {
+      pushFile = fns.pushFileFilterAndCount(filters);
+    } else if (filters.length) {
+      pushFile = fns.pushFileFilter(filters);
+    } else if (onlyCountsVar) {
+      pushFile = fns.pushFileCount;
+    } else {
+      pushFile = fns.pushFile;
     }
   }
 
-  groupFiles(dir, files, state);
-}
-
-function buildFunctions(options, isSync) {
-  const {
-    filters,
-    onlyCountsVar,
-    includeBasePath,
-    includeDirs,
-    groupVar,
-    excludeFn,
-  } = options;
-
-  buildPushFile(filters, onlyCountsVar);
-
-  pushDir = includeDirs ? fns.pushDir : fns.empty;
-
-  // build function for joining paths
-  joinPath = includeBasePath ? fns.joinPathWithBasePath : fns.joinPath;
-
-  // build recursive walk directory function
-  walkDir = excludeFn ? fns.walkDirExclude(excludeFn) : fns.walkDir;
-
-  // build groupFiles function for grouping files
-  groupFiles = groupVar ? fns.groupFiles : fns.empty;
-  getArray = groupVar ? fns.getArrayGroup : fns.getArray;
-
-  buildCallbackInvoker(onlyCountsVar, isSync);
-}
-
-module.exports = { buildFunctions, init, walkSingleDir, readdirOpts };
-
-function buildPushFile(filters, onlyCountsVar) {
-  if (filters.length && onlyCountsVar) {
-    pushFile = fns.pushFileFilterAndCount(filters);
-  } else if (filters.length) {
-    pushFile = fns.pushFileFilter(filters);
-  } else if (onlyCountsVar) {
-    pushFile = fns.pushFileCount;
-  } else {
-    pushFile = fns.pushFile;
+  function buildCallbackInvoker(onlyCountsVar, isSync) {
+    if (onlyCountsVar) {
+      callbackInvoker = isSync
+        ? fns.callbackInvokerOnlyCountsSync
+        : fns.callbackInvokerOnlyCountsAsync;
+    } else {
+      callbackInvoker = isSync
+        ? fns.callbackInvokerDefaultSync
+        : fns.callbackInvokerDefaultAsync;
+    }
   }
-}
 
-function buildCallbackInvoker(onlyCountsVar, isSync) {
-  if (onlyCountsVar) {
-    callbackInvoker = isSync
-      ? fns.callbackInvokerOnlyCountsSync
-      : fns.callbackInvokerOnlyCountsAsync;
-  } else {
-    callbackInvoker = isSync
-      ? fns.callbackInvokerDefaultSync
-      : fns.callbackInvokerDefaultAsync;
-  }
-}
+  /* Dummies that will be filled later conditionally based on options */
+  var pushFile = fns.empty;
+  var pushDir = fns.empty;
+  var walkDir = fns.empty;
+  var joinPath = fns.empty;
+  var groupFiles = fns.empty;
+  var callbackInvoker = fns.empty;
+  var getArray = fns.empty;
 
-/* Dummies that will be filled later conditionally based on options */
-var pushFile = fns.empty;
-var pushDir = fns.empty;
-var walkDir = fns.empty;
-var joinPath = fns.empty;
-var groupFiles = fns.empty;
-var callbackInvoker = fns.empty;
-var getArray = fns.empty;
+  return { init, walkSingleDir };
+}

--- a/src/api/sync.js
+++ b/src/api/sync.js
@@ -1,5 +1,10 @@
 const { readdirSync } = require("../compat/fs");
-const { init, walkSingleDir, readdirOpts } = require("./shared");
+const { makeWalkerFunctions, readdirOpts } = require("./shared");
+
+// For sync usage, we can reuse the same walker functions, because
+// there will not be concurrent calls overwriting the 'built functions'
+// in the middle of everything.
+const { init, walkSingleDir } = makeWalkerFunctions();
 
 function sync(dirPath, options) {
   const { state, callbackInvoker, dir } = init(dirPath, options, null, true);

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -77,10 +77,10 @@ Builder.prototype.glob = function(...patterns) {
       `Please install picomatch: "npm i picomatch" to use glob matching.`
     );
   }
-  var isMatch = globCache[patterns.join()];
+  var isMatch = globCache[patterns.join('\0')];
   if (!isMatch) {
     isMatch = pm(patterns, { dot: true });
-    globCache[patterns.join()] = isMatch;
+    globCache[patterns.join('\0')] = isMatch;
   }
   this.filters.push((path) => isMatch(path));
   return this;


### PR DESCRIPTION
Hello, this PR fixes a few issues!

* Fixes #42
  * I used `'\0'` instead of `'||'` because `\0` is the only character that cannot ever appear in a file path, cross-platform, so no one should ever use that in any glob pattern, while `'||'` could in theory appear in a glob pattern, possibly.

* Fixes #47

* Closes #46