### PR TITLE
Fixed unit tests on Windows machines

### DIFF
--- a/src/compat/fs.js
+++ b/src/compat/fs.js
@@ -46,3 +46,12 @@ if (!Dirent) {
 } else {
   module.exports = { readdirSync, readdir };
 }
+module.exports.getRoot = function(dir) {
+  if(dir.startsWith(sep))
+    return sep;
+  let sep_re = new RegExp(`\\${sep}`);
+  let parts = dir.split(sep_re);
+  let root = parts[0];
+  return root;
+}
+module.exports.getWorkingRoot = function() { return module.exports.getRoot(process.cwd()); };


### PR DESCRIPTION
* Added getWorkingRoot function which returns the root directory of CWD;
  replaced references to the root system mount point "/" with references
  to getWorkingRoot.
* Replaced hard-coded references to Linux filesystem features with dynamic
  references dependent on process.platform or existing platform-agnostic
  functions.
* Added missing configuration options for mock-fs to avoid dirent
  re-creation errors.