### PR TITLE
Implement symlinks support

### DIFF
--- a/__tests__/fdir.test.js
+++ b/__tests__/fdir.test.js
@@ -149,6 +149,30 @@ describe.each(["withPromise", "sync"])("fdir %s", (type) => {
     mock.restore();
   });
 
+  test("crawl all files and include symlinks", async () => {
+    mock({
+      "/sym/linked": {
+        "file-1": "file contents",
+      },
+      "/other/dir": {
+        "file-2": "file contents2",
+      },
+      "/some/dir": {
+        fileSymlink: mock.symlink({
+          path: "/other/dir/file-2",
+        }),
+        dirSymlink: mock.symlink({
+          path: "/sym/linked",
+        }),
+      },
+    });
+    const api = new fdir().withSymlinks().crawl("/some/dir");
+    const files = await api[type]();
+    expect(files.indexOf("/sym/linked/file-1")).toBeGreaterThan(-1);
+    expect(files.indexOf("/other/dir/file-2")).toBeGreaterThan(-1);
+    mock.restore();
+  });
+
   test("crawl all files with only counts", async () => {
     const api = new fdir().onlyCounts().crawl("node_modules");
     const result = await api[type]();

--- a/documentation.md
+++ b/documentation.md
@@ -102,6 +102,18 @@ Use this to also add the directories to the output.
 const crawler = new fdir().withDirs();
 ```
 
+### `withSymlinks`
+
+Use this to resolve and recurse over all symlinks.
+
+> NOTE: This will affect crawling performance so use only if required.
+
+**Usage**
+
+```js
+const crawler = new fdir().withSymlinks();
+```
+
 ### `withMaxDepth(number)`
 
 Use this to limit the maximum depth fdir will crawl to before stopping.

--- a/index.d.ts
+++ b/index.d.ts
@@ -21,6 +21,7 @@ declare module "fdir" {
     group?: boolean;
     onlyCounts?: boolean;
     filters?: FilterFn[];
+    resolveSymlinks?: boolean;
     excludeFiles?: boolean;
     exclude?: ExcludeFn;
   };
@@ -53,6 +54,11 @@ declare module "fdir" {
      * Include directories in the output
      */
     withDirs(): Builder;
+
+    /**
+     * Resolve and recurse over all symlinks
+     */
+     withSymlinks(): Builder;
 
     /**
      * The depth to crawl to before stopping

--- a/src/api/queue.js
+++ b/src/api/queue.js
@@ -1,0 +1,14 @@
+function Queue(onQueueEmpty) {
+  this.onQueueEmpty = onQueueEmpty;
+  this.queuedCount = 0;
+}
+
+Queue.prototype.queue = function () {
+  this.queuedCount++;
+};
+
+Queue.prototype.dequeue = function (...args) {
+  if (--this.queuedCount === 0) this.onQueueEmpty(...args);
+};
+
+module.exports = Queue;

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -62,6 +62,7 @@ Builder.prototype.withErrors = function() {
 
 Builder.prototype.withSymlinks = function() {
   this.resolveSymlinks = true;
+  this.withFullPaths();
   return this;
 };
 

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -60,6 +60,11 @@ Builder.prototype.withErrors = function() {
   return this;
 };
 
+Builder.prototype.withSymlinks = function() {
+  this.resolveSymlinks = true;
+  return this;
+};
+
 Builder.prototype.group = function() {
   this.groupVar = true;
   return this;

--- a/src/compat/fs.js
+++ b/src/compat/fs.js
@@ -41,6 +41,7 @@ if (!Dirent) {
       name,
       isFile: () => stat.isFile(),
       isDirectory: () => stat.isDirectory(),
+      isSymbolicLink: () => stat.isSymbolicLink(),
     };
   }
 } else {


### PR DESCRIPTION
Closes #53 

Symlinks are resolved using a combination of `realpath` & `lstat`. Since fdir supports both sync & async APIs, I had to add a basic queue system.

**`Queue`**:
Queue works by incrementing a counter everytime an async call is made and decrementing it once it is done. Once the counter === 0, it invokes the `onQueueEmpty` callback.

> This allows us to use async functions with callbacks almost anywhere.

**TODO**:
1. There are no tests for the symlinks support.
2. Internal function naming in fdir is all over the place. (this will be done in a separate PR)