### PR TITLE
Add picomatch in peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "systeminformation": "^5.3.1",
     "tiny-glob": "^0.2.9",
     "walk-sync": "^2.0.2"
+  },
+  "peerDependencies": {
+    "picomatch": "2.x"
   }
 }


### PR DESCRIPTION
This will allow adopting libraries use `picomatch` without error and without it being a required dependency to install.