### PR TITLE
Make picomatch an optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,5 +65,10 @@
   },
   "peerDependencies": {
     "picomatch": "2.x"
+  },
+  "peerDependenciesMeta": {
+    "picomatch": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
Building off of https://github.com/thecodrr/fdir/pull/76, this makes picomatch an optional peer dependency, to avoid it from being automatically installed by some package managers, or throwing warnings in others.

@thecodrr I'd love if you could take a look at this and hopefully merge and release a new version soon, so it can unblock me on https://github.com/storybookjs/storybook/pull/19297 in adding this library to Storybook.