### PR TITLE
Add support for returning symlinked paths

### DIFF
--- a/__tests__/fdir.test.js
+++ b/__tests__/fdir.test.js
@@ -170,6 +170,34 @@ describe.each(["withPromise", "sync"])("fdir %s", (type) => {
     const api = new fdir().withSymlinks().crawl("/some/dir");
     const files = await api[type]();
     expect(files.length).toBe(2);
+    expect(files.indexOf("/some/dir/fileSymlink/")).toBeGreaterThan(-1);
+    expect(files.indexOf("/some/dir/dirSymlink/file-1")).toBeGreaterThan(-1);
+    mock.restore();
+  });
+
+  test("crawl all files and include symlinks with real paths", async () => {
+    mock({
+      "/sym/linked": {
+        "file-1": "file contents",
+      },
+      "/other/dir": {
+        "file-2": "file contents2",
+      },
+      "/some/dir": {
+        fileSymlink: mock.symlink({
+          path: "/other/dir/file-2",
+        }),
+        dirSymlink: mock.symlink({
+          path: "/sym/linked",
+        }),
+      },
+    });
+    const api = new fdir()
+      .withSymlinks()
+      .withRealPaths()
+      .crawl("/some/dir");
+    const files = await api[type]();
+    expect(files.length).toBe(2);
     expect(files.indexOf("/sym/linked/file-1")).toBeGreaterThan(-1);
     expect(files.indexOf("/other/dir/file-2")).toBeGreaterThan(-1);
     mock.restore();

--- a/documentation.md
+++ b/documentation.md
@@ -104,14 +104,28 @@ const crawler = new fdir().withDirs();
 
 ### `withSymlinks`
 
-Use this to resolve and recurse over all symlinks.
+By default `fdir` does not follow symlinks but if such a functionality is required, you can use this flag. Do note that the returned paths are not real paths i.e., they are not relative to the original directory but the symlink itself. You can change this behavior by using `withRealPaths`.
 
-> NOTE: This will affect crawling performance so use only if required.
+> NOTE: This will affect crawling performance.
 
 **Usage**
 
 ```js
 const crawler = new fdir().withSymlinks();
+```
+
+### `withRealPaths`
+
+This changes the default behavior of `withSymlinks` to return real paths instead of the symlinked paths.
+
+Do note that using `withRealPaths` will be slower since `fdir` will call `realpath` in addition to `stat`. 2 calls instead of 1 so only use this if absolutely required.
+
+**This is intended to be used with `withSymlinks`**
+
+**Usage**
+
+```js
+const crawler = new fdir().withSymlinks().withRealPaths();
 ```
 
 ### `withMaxDepth(number)`

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,7 @@ declare module "fdir" {
     excludeFiles?: boolean;
     exclude?: ExcludeFn;
     relativePaths?: boolean;
+    useRealPaths?: boolean;
   };
 
   class APIBuilder {
@@ -57,9 +58,14 @@ declare module "fdir" {
     withDirs(): Builder;
 
     /**
-     * Resolve and recurse over all symlinks
+     * Recursively follow all symlinks
      */
     withSymlinks(): Builder;
+
+    /**
+     * Return real paths for symlinked files & directories
+     */
+    withRealPaths(): Builder;
 
     /**
      * Return paths relative to the root directory

--- a/src/api/fns.js
+++ b/src/api/fns.js
@@ -90,7 +90,7 @@ function callbackInvokerBuilder(output) {
 module.exports.resolveSymlinksAsync = function(path, state, callback) {
   state.queue.queue();
 
-  fs.lstat(path, (error, stat) => {
+  fs.stat(path, (error, stat) => {
     if (error) {
       state.queue.dequeue(state.options.suppressErrors ? null : error, state);
       return;
@@ -128,7 +128,7 @@ module.exports.resolveSymlinksWithRealPathsAsync = function(
 };
 
 module.exports.resolveSymlinksSync = function(path, _state, callback) {
-  const stat = fs.lstatSync(path);
+  const stat = fs.statSync(path);
   callback(stat, path);
 };
 

--- a/src/api/fns.js
+++ b/src/api/fns.js
@@ -90,27 +90,54 @@ function callbackInvokerBuilder(output) {
 module.exports.resolveSymlinksAsync = function(path, state, callback) {
   state.queue.queue();
 
-  fs.realpath(path, (error, resolvedPath) => {
+  fs.lstat(path, (error, stat) => {
     if (error) {
       state.queue.dequeue(state.options.suppressErrors ? null : error, state);
       return;
     }
 
-    fs.lstat(resolvedPath, (error, stat) => {
+    callback(stat, path);
+
+    state.queue.dequeue(null, state);
+  });
+};
+
+module.exports.resolveSymlinksWithRealPathsAsync = function(
+  path,
+  state,
+  callback
+) {
+  state.queue.queue();
+
+  fs.stat(path, (error, stat) => {
+    if (error) {
+      state.queue.dequeue(state.options.suppressErrors ? null : error, state);
+      return;
+    }
+
+    fs.realpath(path, (error, resolvedPath) => {
       if (error) {
         state.queue.dequeue(state.options.suppressErrors ? null : error, state);
         return;
       }
 
       callback(stat, resolvedPath);
-
       state.queue.dequeue(null, state);
     });
   });
 };
 
 module.exports.resolveSymlinksSync = function(path, _state, callback) {
+  const stat = fs.lstatSync(path);
+  callback(stat, path);
+};
+
+module.exports.resolveSymlinksWithRealPathsSync = function(
+  path,
+  _state,
+  callback
+) {
+  const stat = fs.statSync(path);
   const resolvedPath = fs.realpathSync(path);
-  const stat = fs.lstatSync(resolvedPath);
   callback(stat, resolvedPath);
 };

--- a/src/api/walker.js
+++ b/src/api/walker.js
@@ -121,6 +121,7 @@ Walker.prototype.buildFunctions = function buildFunctions() {
     excludeFiles,
     resolveSymlinks,
     isSync,
+    useRealPaths,
   } = this.options;
 
   // build function for joining paths
@@ -138,7 +139,7 @@ Walker.prototype.buildFunctions = function buildFunctions() {
 
   this.buildPushDir(includeDirs, filters);
 
-  this.buildSymlinkResolver(resolveSymlinks, isSync);
+  this.buildSymlinkResolver(resolveSymlinks, useRealPaths, isSync);
 
   this.buildCallbackInvoker(onlyCountsVar, isSync);
 };
@@ -188,12 +189,17 @@ Walker.prototype.buildCallbackInvoker = function buildCallbackInvoker(
  */
 Walker.prototype.buildSymlinkResolver = function buildSymlinkResolver(
   resolveSymlinks,
+  useRealPaths,
   isSync
 ) {
   if (!resolveSymlinks) return;
 
   this.symlinkResolver = isSync
-    ? fns.resolveSymlinksSync
+    ? useRealPaths
+      ? fns.resolveSymlinksWithRealPathsSync
+      : fns.resolveSymlinksSync
+    : useRealPaths
+    ? fns.resolveSymlinksWithRealPathsAsync
     : fns.resolveSymlinksAsync;
 };
 

--- a/src/builder/index.js
+++ b/src/builder/index.js
@@ -73,6 +73,11 @@ Builder.prototype.withSymlinks = function() {
   return this;
 };
 
+Builder.prototype.withRealPaths = function() {
+  this.useRealPaths = true;
+  return this;
+};
+
 Builder.prototype.group = function() {
   this.groupVar = true;
   return this;


### PR DESCRIPTION
This adds a new builder method `withRealPaths` which should give the previous behavior. By default symlinked paths will not be resolved.

Closes #83 