### PR TITLE
feat: allow custom glob functions other than picomatch

### DIFF
--- a/__tests__/fdir.test.ts
+++ b/__tests__/fdir.test.ts
@@ -1,7 +1,7 @@
 import { fdir } from "../src/index";
 import fs from "fs";
 import mock from "mock-fs";
-import { test, beforeEach, TestContext } from "vitest";
+import { test, beforeEach, TestContext, vi } from "vitest";
 import path, { sep } from "path";
 import { convertSlashes } from "../src/utils";
 
@@ -409,6 +409,32 @@ for (const type of apiTypes) {
     ).toBeTruthy();
 
     mock.restore();
+  });
+
+  test(`[${type}] crawl files that match using a custom glob`, async (t) => {
+    const globFunction = vi.fn((glob: string | string[]) => {
+      return (test: string): boolean => test.endsWith(".js");
+    });
+    const api = new fdir({globFunction})
+      .withBasePath()
+      .glob("**/*.js")
+      .crawl("node_modules");
+    const files = await api[type]();
+    t.expect(globFunction).toHaveBeenCalled();
+    t.expect(files.every((file) => file.endsWith(".js"))).toBeTruthy();
+  });
+
+  test(`[${type}] crawl files that match using a custom glob with options`, async (t) => {
+    const globFunction = vi.fn((glob: string | string[], options?: {foo: number}) => {
+      return (test: string): boolean => test.endsWith(".js");
+    });
+    const api = new fdir({globFunction})
+      .withBasePath()
+      .globWithOptions(["**/*.js"], {foo: 5})
+      .crawl("node_modules");
+    const files = await api[type]();
+    t.expect(globFunction).toHaveBeenCalled();
+    t.expect(files.every((file) => file.endsWith(".js"))).toBeTruthy();
   });
 }
 

--- a/__tests__/fdir.test.ts
+++ b/__tests__/fdir.test.ts
@@ -4,6 +4,7 @@ import mock from "mock-fs";
 import { test, beforeEach, TestContext, vi } from "vitest";
 import path, { sep } from "path";
 import { convertSlashes } from "../src/utils";
+import picomatch from "picomatch";
 
 beforeEach(() => {
   mock.restore();
@@ -435,6 +436,28 @@ for (const type of apiTypes) {
     const files = await api[type]();
     t.expect(globFunction).toHaveBeenCalled();
     t.expect(files.every((file) => file.endsWith(".js"))).toBeTruthy();
+  });
+
+  test(`[${type}] crawl files that match using a picomatch`, async (t) => {
+    const globFunction = picomatch;
+    const api = new fdir({globFunction})
+      .withBasePath()
+      .glob("**/*.js")
+      .crawl("node_modules");
+    const files = await api[type]();
+    t.expect(files.every((file) => file.endsWith(".js"))).toBeTruthy();
+  });
+
+  test(`[${type}] using withGlobFunction to set glob`, async (t) => {
+    const globFunction = vi.fn((glob: string | string[], input: string) => {
+      return (test: string): boolean => test === input;
+    });
+    new fdir()
+      .withBasePath()
+      .withGlobFunction(globFunction)
+      .globWithOptions(["**/*.js"], "bleep")
+      .crawl("node_modules");
+    t.expect(globFunction).toHaveBeenCalledWith(["**/*.js"], "bleep");
   });
 }
 

--- a/documentation.md
+++ b/documentation.md
@@ -286,6 +286,24 @@ const crawler = new fdir().globWithOptions(["**/*.js", "**/*.md"], {
 });
 ```
 
+### `withGlobFunction(Function)`
+
+Uses the specified glob function to match files against the provided glob pattern.
+
+**Usage**
+
+```js
+// using picomatch or a similar library
+import picomatch from 'picomatch';
+const crawler = new fdir().withGlobFunction(picomatch);
+
+// using a custom function
+const customGlob = (patterns: string | string[]) => {
+  return (test: string): boolean => test.endsWith('.js');
+};
+const crawler = new fdir().withGlobFunction(customGlob);
+```
+
 ### `filter(Function)`
 
 Applies a filter to all directories and files and only adds those that satisfy the filter.
@@ -431,5 +449,6 @@ type Options = {
   relativePaths?: boolean;
   pathSeparator: PathSeparator;
   signal?: AbortSignal;
+  globFunction?: Function;
 };
 ```

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export type ResultCallback<TOutput extends Output> = (
 export type FilterPredicate = (path: string, isDirectory: boolean) => boolean;
 export type ExcludePredicate = (dirName: string, dirPath: string) => boolean;
 export type PathSeparator = "/" | "\\";
-export type Options = {
+export type Options<TGlobFunction extends GlobFunction = GlobFunction> = {
   includeBasePath?: boolean;
   includeDirs?: boolean;
   normalizePath?: boolean;
@@ -59,4 +59,13 @@ export type Options = {
   relativePaths?: boolean;
   pathSeparator: PathSeparator;
   signal?: AbortSignal;
+  globFunction?: TGlobFunction
 };
+
+export type GlobMatcher = (test: string) => boolean;
+export type GlobFunction =
+  ((glob: string | string[], ...params: never[]) => GlobMatcher);
+export type GlobParams<T extends GlobFunction> =
+  T extends (globs: string|string[], ...params: infer TParams extends unknown[]) => GlobMatcher
+    ? TParams
+    : [];

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export type ResultCallback<TOutput extends Output> = (
 export type FilterPredicate = (path: string, isDirectory: boolean) => boolean;
 export type ExcludePredicate = (dirName: string, dirPath: string) => boolean;
 export type PathSeparator = "/" | "\\";
-export type Options<TGlobFunction extends GlobFunction = GlobFunction> = {
+export type Options<TGlobFunction = unknown> = {
   includeBasePath?: boolean;
   includeDirs?: boolean;
   normalizePath?: boolean;
@@ -64,8 +64,8 @@ export type Options<TGlobFunction extends GlobFunction = GlobFunction> = {
 
 export type GlobMatcher = (test: string) => boolean;
 export type GlobFunction =
-  ((glob: string | string[], ...params: never[]) => GlobMatcher);
-export type GlobParams<T extends GlobFunction> =
+  ((glob: string | string[], ...params: unknown[]) => GlobMatcher);
+export type GlobParams<T> =
   T extends (globs: string|string[], ...params: infer TParams extends unknown[]) => GlobMatcher
     ? TParams
     : [];


### PR DESCRIPTION
This allows you to pass in your own `globFunction` rather than picomatch, so we're not forcing a choice here (someone may want to use a simpler library or a newer picomatch).

Example:

```ts
function globFunction(
  patterns: string | string[],
) {
  return (test) => {
    // some glob match logic
  };
}

const api = new fdir({globFunction})
  .glob('*.js')
  .crawl(cwd);
const files = await api.withPromise();
```

benchmark seems to be about the same as before on my machine

this also means the options stay strongly typed for whatever glob function you use i think. some example of that:

```ts
interface GlobOptions {
  x: number;
}

declare function globFunction(patterns: string|string[], options?: GlobOptions): GlobMatcher;

const api = new fdir({globFunction});

api.globWithOptions(
  ['*.js'],
  {
    x: 100, // works
    y: 200, // errors, since `GlobOptions` has no such prop
  }
);
```