### PR TITLE
feat: add `withSymlinks` argument back

### DIFF
--- a/documentation.md
+++ b/documentation.md
@@ -102,7 +102,7 @@ Use this to also add the directories to the output.
 const crawler = new fdir().withDirs();
 ```
 
-### `withSymlinks(boolean)`
+### `withSymlinks({ resolvePaths: boolean })`
 
 Use this to follow all symlinks recursively.
 
@@ -116,10 +116,10 @@ Use this to follow all symlinks recursively.
 
 ```js
 // to resolve all symlinked paths to their original path
-const crawler = new fdir().withSymlinks(true);
+const crawler = new fdir().withSymlinks({ resolvePaths: true });
 
 // to disable path resolution
-const crawler = new fdir().withSymlinks(false);
+const crawler = new fdir().withSymlinks({ resolvePaths: false });
 ```
 
 ### `withMaxDepth(number)`
@@ -379,6 +379,7 @@ type Options = {
   onlyCounts?: boolean;
   filters?: FilterFn[];
   resolveSymlinks?: boolean;
+  useRealPaths?: boolean;
   excludeFiles?: boolean;
   exclude?: ExcludeFn;
   relativePaths?: boolean;

--- a/src/api/functions/resolve-symlink.ts
+++ b/src/api/functions/resolve-symlink.ts
@@ -18,7 +18,7 @@ const resolveSymlinksAsync: ResolveSymlinkFunction = function(
   } = state;
   queue.enqueue();
 
-  fs.stat(path, (error, stat) => {
+  fs.lstat(path, (error, stat) => {
     if (error) {
       queue.dequeue(suppressErrors ? null : error, state);
       return;
@@ -60,7 +60,7 @@ const resolveSymlinksSync: ResolveSymlinkFunction = function(
   callback
 ) {
   try {
-    const stat = fs.statSync(path);
+    const stat = fs.lstatSync(path);
     callback(stat, path);
   } catch (e) {
     if (!state.options.suppressErrors) throw e;

--- a/src/api/functions/resolve-symlink.ts
+++ b/src/api/functions/resolve-symlink.ts
@@ -18,7 +18,7 @@ const resolveSymlinksAsync: ResolveSymlinkFunction = function(
   } = state;
   queue.enqueue();
 
-  fs.lstat(path, (error, stat) => {
+  fs.stat(path, (error, stat) => {
     if (error) {
       queue.dequeue(suppressErrors ? null : error, state);
       return;
@@ -60,7 +60,7 @@ const resolveSymlinksSync: ResolveSymlinkFunction = function(
   callback
 ) {
   try {
-    const stat = fs.lstatSync(path);
+    const stat = fs.statSync(path);
     callback(stat, path);
   } catch (e) {
     if (!state.options.suppressErrors) throw e;

--- a/src/api/functions/resolve-symlink.ts
+++ b/src/api/functions/resolve-symlink.ts
@@ -87,9 +87,11 @@ export function build(
 ): ResolveSymlinkFunction | null {
   if (!options.resolveSymlinks) return null;
 
-  if (isSynchronous) {
-    return options.useRealPaths ? resolveSymlinksWithRealPathsSync :  resolveSymlinksSync
-  }
-
-  return options.useRealPaths ? resolveSymlinksWithRealPathsAsync : resolveSymlinksAsync;
+  if (options.useRealPaths)
+    return isSynchronous
+        ? resolveSymlinksWithRealPathsSync
+        : resolveSymlinksWithRealPathsAsync;
+  return isSynchronous
+    ? resolveSymlinksSync
+    : resolveSymlinksAsync;
 }

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -80,8 +80,9 @@ export class Builder<TReturnType extends Output = PathsOutput> {
     return this;
   }
 
-  withSymlinks() {
+  withSymlinks({ resolvePaths = true } = {}) {
     this.options.resolveSymlinks = true;
+    this.options.useRealPaths = resolvePaths;
     return this.withFullPaths();
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,7 @@ export type Options = {
   onlyCounts?: boolean;
   filters: FilterPredicate[];
   resolveSymlinks?: boolean;
+  useRealPaths?: boolean;
   excludeFiles?: boolean;
   exclude?: ExcludePredicate;
   relativePaths?: boolean;


### PR DESCRIPTION
While working on `tinyglobby` I've noticed there is no way to disable `fdir` returning the real path of a symlink anymore, due to #81 silently removing support for it (even though the documentation still mentions the feature!).

This PR adds it back, inside an object parameter instead for better API design (see https://github.com/thecodrr/fdir/issues/83#issuecomment-1282787956). It defaults to `true` for backwards compatibility

Closes #103