### PR TITLE
fix: support symlinks without real paths with relative paths enabled

### DIFF
--- a/__tests__/fdir.test.ts
+++ b/__tests__/fdir.test.ts
@@ -334,15 +334,39 @@ for (const type of apiTypes) {
     const api = new fdir()
       .withSymlinks({ resolvePaths: false })
       .withRelativePaths()
-      .withPathSeparator("/")
       .crawl("/some/dir");
     const files = await api[type]();
     t.expect(files).toHaveLength(3);
     t.expect(
-      files.indexOf("dirSymlink/file-1") > -1
+      files.indexOf(path.join("dirSymlink", "file-1")) > -1
     ).toBeTruthy();
     t.expect(
-      files.indexOf("dirSymlink/file-excluded-1") > -1
+      files.indexOf(path.join("dirSymlink", "file-excluded-1")) > -1
+    ).toBeTruthy();
+    t.expect(
+      files.indexOf("fileSymlink") > -1
+    ).toBeTruthy();
+    mock.restore();
+  });
+
+  // fdir doesn't support this usecase
+  test(`[${type}] crawl all files and include resolved symlinks with real paths with relative paths on`, async (t) => {
+    mock(mockFsWithSymlinks);
+
+    const api = new fdir()
+      .withSymlinks()
+      .withRelativePaths()
+      .crawl("/some/dir");
+    const files = await api[type]();
+    t.expect(files).toHaveLength(3);
+    t.expect(
+      files.indexOf(path.join("d", "file-1")) > -1
+    ).toBeTruthy();
+    t.expect(
+      files.indexOf(path.join("d", "file-excluded-1")) > -1
+    ).toBeTruthy();
+    t.expect(
+      files.indexOf(`${path.sep}file-2`) > -1
     ).toBeTruthy();
     mock.restore();
   });

--- a/__tests__/fdir.test.ts
+++ b/__tests__/fdir.test.ts
@@ -328,6 +328,25 @@ for (const type of apiTypes) {
     mock.restore();
   });
 
+  test(`[${type}] crawl all files and include resolved symlinks without real paths with relative paths on`, async (t) => {
+    mock(mockFsWithSymlinks);
+
+    const api = new fdir()
+      .withSymlinks({ resolvePaths: false })
+      .withRelativePaths()
+      .withPathSeparator("/")
+      .crawl("/some/dir");
+    const files = await api[type]();
+    t.expect(files).toHaveLength(3);
+    t.expect(
+      files.indexOf("dirSymlink/file-1") > -1
+    ).toBeTruthy();
+    t.expect(
+      files.indexOf("dirSymlink/file-excluded-1") > -1
+    ).toBeTruthy();
+    mock.restore();
+  });
+
   test("crawl all files and include resolved symlinks with exclusions", async (t) => {
     mock(mockFsWithSymlinks);
     const api = new fdir()

--- a/documentation.md
+++ b/documentation.md
@@ -104,7 +104,7 @@ const crawler = new fdir().withDirs();
 
 ### `withSymlinks({ resolvePaths: boolean })`
 
-Use this to follow all symlinks recursively.
+Use this to follow all symlinks recursively. Not available with relative paths on unless the parameter is set to `false`.
 
 **Parameters:**
 

--- a/src/api/functions/join-path.ts
+++ b/src/api/functions/join-path.ts
@@ -1,6 +1,6 @@
 import { Options, PathSeparator } from "../../types";
 
-function joinPathWithBasePath(filename: string, directoryPath: string) {
+export function joinPathWithBasePath(filename: string, directoryPath: string) {
   return directoryPath + filename;
 }
 


### PR DESCRIPTION
fixes #113

when investigating, i found out that the issue was caused by the following line:

https://github.com/thecodrr/fdir/blob/5a0aab5b3e108eaf677e0e39c22ff1ea03cd1a59/src/api/walker.ts#L120-L121

with relative paths on, `path` won't be an absolute path, and as such will be resolved in the `stat` call as a path relative to `process.cwd()`. this makes it throw an `ENOENT` error (unless the symlink happens to be located in `process.cwd()`). i fixed this by changing the declaration to make it an absolute path instead.

just fixing this line wasn't enough though, because the `resolvedPath` seems to always be absolute. to fix this, i did a substring transformation to a relative path (if the symlink is a file) if the `relativePaths` option is enabled and `useRealPaths` is `false`. the latter is because symlinks can point anywhere in the filesystem, so it should return an absolute path when that is the case.

directory symlinks with real paths sadly still do not work with `relativePaths` on. my plan was to make it return those as absolute paths, but that is impossible as the `joinPath` function is already built as the relative path implementation

since symlinks with real paths and relative paths still behave inconsistently before and after this pr, i marked in the docs that resolving symlinks with real paths is only supported if the `resolveSymlinks` argument is set to `false`

also, while working on this i found (and fixed) another bug, it looks like file symlinks were never normalized, and as such could have the wrong path separator etc. fixed this by moving the `normalizePath` call before the `stat.isDirectory()` check