### PR TITLE
feat: add support for excluding symlinks

### DIFF
--- a/__tests__/fdir.test.ts
+++ b/__tests__/fdir.test.ts
@@ -355,6 +355,15 @@ for (const type of apiTypes) {
     mock.restore();
   });
 
+  test(`[${type}] crawl all files and exclude symlinks`, async (t) => {
+    mock(mockFsWithSymlinks);
+
+    const api = new fdir({ excludeSymlinks: true }).crawl("/some/dir");
+    const files = await api[type]();
+    t.expect(files).toHaveLength(0);
+    mock.restore();
+  });
+
   test(`[${type}] crawl all files and invert path separator`, async (t) => {
     const api = new fdir()
       .withPathSeparator(sep === "/" ? "\\" : "/")

--- a/documentation.md
+++ b/documentation.md
@@ -427,6 +427,7 @@ type Options = {
   resolveSymlinks?: boolean;
   useRealPaths?: boolean;
   excludeFiles?: boolean;
+  excludeSymlinks?: boolean;
   exclude?: ExcludeFn;
   relativePaths?: boolean;
   pathSeparator: PathSeparator;

--- a/src/api/functions/resolve-symlink.ts
+++ b/src/api/functions/resolve-symlink.ts
@@ -85,7 +85,7 @@ export function build(
   options: Options,
   isSynchronous: boolean
 ): ResolveSymlinkFunction | null {
-  if (!options.resolveSymlinks) return null;
+  if (!options.resolveSymlinks || options.excludeSymlinks) return null;
 
   if (options.useRealPaths)
     return isSynchronous

--- a/src/api/walker.ts
+++ b/src/api/walker.ts
@@ -93,7 +93,7 @@ export class Walker<TOutput extends Output> {
   private walk = (entries: Dirent[], directoryPath: string, depth: number) => {
     const {
       paths,
-      options: { filters, resolveSymlinks, exclude, maxFiles, signal },
+      options: { filters, resolveSymlinks, excludeSymlinks, exclude, maxFiles, signal },
     } = this.state;
 
     if ((signal && signal.aborted) || (maxFiles && paths.length > maxFiles))
@@ -105,7 +105,7 @@ export class Walker<TOutput extends Output> {
     for (let i = 0; i < entries.length; ++i) {
       const entry = entries[i];
 
-      if (entry.isFile() || (entry.isSymbolicLink() && !resolveSymlinks && !this.state.options.excludeSymlinks)) {
+      if (entry.isFile() || (entry.isSymbolicLink() && !resolveSymlinks && !excludeSymlinks)) {
         const filename = this.joinPath(entry.name, directoryPath);
         this.pushFile(filename, files, this.state.counts, filters);
       } else if (entry.isDirectory()) {
@@ -116,7 +116,7 @@ export class Walker<TOutput extends Output> {
         );
         if (exclude && exclude(entry.name, path)) continue;
         this.walkDirectory(this.state, path, depth - 1, this.walk);
-      } else if (entry.isSymbolicLink() && resolveSymlinks && !this.state.options.excludeSymlinks) {
+      } else if (entry.isSymbolicLink() && resolveSymlinks && !excludeSymlinks) {
         let path = this.joinPath(entry.name, directoryPath);
         this.resolveSymlink!(path, this.state, (stat, resolvedPath) => {
           if (stat.isDirectory()) {

--- a/src/api/walker.ts
+++ b/src/api/walker.ts
@@ -105,7 +105,7 @@ export class Walker<TOutput extends Output> {
     for (let i = 0; i < entries.length; ++i) {
       const entry = entries[i];
 
-      if (entry.isFile() || (entry.isSymbolicLink() && !resolveSymlinks)) {
+      if (entry.isFile() || (entry.isSymbolicLink() && !resolveSymlinks && !this.state.options.excludeSymlinks)) {
         const filename = this.joinPath(entry.name, directoryPath);
         this.pushFile(filename, files, this.state.counts, filters);
       } else if (entry.isDirectory()) {
@@ -116,7 +116,7 @@ export class Walker<TOutput extends Output> {
         );
         if (exclude && exclude(entry.name, path)) continue;
         this.walkDirectory(this.state, path, depth - 1, this.walk);
-      } else if (entry.isSymbolicLink() && resolveSymlinks) {
+      } else if (entry.isSymbolicLink() && resolveSymlinks && !this.state.options.excludeSymlinks) {
         let path = this.joinPath(entry.name, directoryPath);
         this.resolveSymlink!(path, this.state, (stat, resolvedPath) => {
           if (stat.isDirectory()) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export type Options = {
   resolveSymlinks?: boolean;
   useRealPaths?: boolean;
   excludeFiles?: boolean;
+  excludeSymlinks?: boolean;
   exclude?: ExcludePredicate;
   relativePaths?: boolean;
   pathSeparator: PathSeparator;


### PR DESCRIPTION
when `resolveSymlinks` is not set, symlinks just get treated as files. this adds support for individually excluding symlinks from the result

why? because fdir currently has ways of excluding files and directories, but not symlinks (and also because it was requested in SuperchupuDev/tinyglobby#26)