### PR TITLE
fix: do not return an empty string for the root

### DIFF
--- a/src/api/functions/push-directory.ts
+++ b/src/api/functions/push-directory.ts
@@ -8,7 +8,7 @@ export type PushDirectoryFunction = (
 
 function pushDirectoryWithRelativePath(root: string): PushDirectoryFunction {
   return function (directoryPath, paths) {
-    paths.push((directoryPath || ".").substring(root.length));
+    paths.push(directoryPath.substring(root.length) || ".");
   };
 }
 
@@ -16,7 +16,7 @@ function pushDirectoryFilterWithRelativePath(
   root: string
 ): PushDirectoryFunction {
   return function (directoryPath, paths, filters) {
-    const relativePath = directoryPath.substring(root.length);
+    const relativePath = directoryPath.substring(root.length) || ".";
     if (filters!.every((filter) => filter(relativePath, true))) {
       paths.push(relativePath);
     }
@@ -32,8 +32,9 @@ const pushDirectoryFilter: PushDirectoryFunction = (
   paths,
   filters
 ) => {
-  if (filters!.every((filter) => filter(directoryPath, true))) {
-    paths.push(directoryPath);
+  const path = directoryPath || ".";
+  if (filters!.every((filter) => filter(path, true))) {
+    paths.push(path);
   }
 };
 

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -124,7 +124,7 @@ export class Builder<
     return this as Builder<OnlyCountsOutput, TGlobFunction>;
   }
 
-  crawl(root: string) {
+  crawl(root?: string) {
     return new APIBuilder<TReturnType>(root || ".", this.options);
   }
 


### PR DESCRIPTION
also adds more tests that are related to `pushDirectory`, and corrects the type of `.crawl`'s argument

doing this, the project is fully covered by tests except for the error handling in `resolveSymlinks`, that i am not sure how to hit