### PR TITLE
fix: do not incorrectly use real paths on exclude predicate

### DIFF
--- a/__tests__/symlinks.test.ts
+++ b/__tests__/symlinks.test.ts
@@ -341,6 +341,15 @@ for (const type of apiTypes) {
       t.expect(files.sort()).toStrictEqual(normalize(["/other/dir/file-2"]));
     });
 
+    test("resolve symlinks (exclude /some/dir/, real paths: false)", async (t) => {
+      const api = new fdir()
+        .withSymlinks({ resolvePaths: false })
+        .exclude((_name, path) => path === resolveSymlinkRoot("/some/dir/dirSymlink/"))
+        .crawl("/some/dir")
+      const files = await api[type]();
+      t.expect(files.sort()).toStrictEqual(normalize(["/some/dir/fileSymlink"]));
+    });
+
     test(`do not resolve symlinks`, async (t) => {
       const api = new fdir().crawl("/some/dir");
       const files = await api[type]();

--- a/__tests__/symlinks.test.ts
+++ b/__tests__/symlinks.test.ts
@@ -341,7 +341,7 @@ for (const type of apiTypes) {
       t.expect(files.sort()).toStrictEqual(normalize(["/other/dir/file-2"]));
     });
 
-    test("resolve symlinks (exclude /some/dir/, real paths: false)", async (t) => {
+    test("resolve symlinks (exclude /some/dir/dirSymlink/, real paths: false)", async (t) => {
       const api = new fdir()
         .withSymlinks({ resolvePaths: false })
         .exclude((_name, path) => path === resolveSymlinkRoot("/some/dir/dirSymlink/"))

--- a/src/api/walker.ts
+++ b/src/api/walker.ts
@@ -118,7 +118,7 @@ export class Walker<TOutput extends Output> {
         this.resolveSymlink(path, this.state, (stat, resolvedPath) => {
           if (stat.isDirectory()) {
             resolvedPath = normalizePath(resolvedPath, this.state.options);
-            if (exclude && exclude(entry.name, resolvedPath)) return;
+            if (exclude && exclude(entry.name, useRealPaths ? resolvedPath : path + pathSeparator)) return;
 
             this.walkDirectory(
               this.state,


### PR DESCRIPTION
see the e18e discord for discussion, sorry i didn't have time to open an issue

the exclude predicate always used real paths on symlinks, this should fix that