### PR TITLE
Fix hang when crawling root with direct symlinks

### DIFF
--- a/__tests__/symlinks.test.ts
+++ b/__tests__/symlinks.test.ts
@@ -354,14 +354,10 @@ for (const type of apiTypes) {
     test("resolve symlinks (exclude /some/dir/dirSymlink/, real paths: false)", async (t) => {
       const api = new fdir()
         .withSymlinks({ resolvePaths: false })
-        .exclude(
-          (_name, path) => path === resolveSymlinkRoot("/some/dir/dirSymlink/")
-        )
+        .exclude((_name, path) => path === resolveSymlinkRoot("/some/dir/dirSymlink/"))
         .crawl("/some/dir");
       const files = await api[type]();
-      t.expect(files.sort()).toStrictEqual(
-        normalize(["/some/dir/fileSymlink"])
-      );
+      t.expect(files.sort()).toStrictEqual(normalize(["/some/dir/fileSymlink"]));
     });
 
     test(`do not resolve symlinks`, async (t) => {

--- a/__tests__/symlinks.test.ts
+++ b/__tests__/symlinks.test.ts
@@ -354,10 +354,14 @@ for (const type of apiTypes) {
     test("resolve symlinks (exclude /some/dir/dirSymlink/, real paths: false)", async (t) => {
       const api = new fdir()
         .withSymlinks({ resolvePaths: false })
-        .exclude((_name, path) => path === resolveSymlinkRoot("/some/dir/dirSymlink/"))
-        .crawl("/some/dir")
+        .exclude(
+          (_name, path) => path === resolveSymlinkRoot("/some/dir/dirSymlink/")
+        )
+        .crawl("/some/dir");
       const files = await api[type]();
-      t.expect(files.sort()).toStrictEqual(normalize(["/some/dir/fileSymlink"]));
+      t.expect(files.sort()).toStrictEqual(
+        normalize(["/some/dir/fileSymlink"])
+      );
     });
 
     test(`do not resolve symlinks`, async (t) => {
@@ -374,15 +378,11 @@ for (const type of apiTypes) {
       t.expect(files).toHaveLength(0);
     });
 
-    test("doesn't hang when resolving symlinks in the root directory", async () => {
-        await new fdir()
-          .exclude((_1, _2) => {
-            // Avoid crawling recursively for better test runtime.
-            return true;
-          })
-          .withSymlinks({ resolvePaths: false })
-          .crawl("/")
-          .withPromise();
+    test(
+      "doesn't hang when resolving symlinks in the root directory",
+      async () => {
+        const api = new fdir().withSymlinks({ resolvePaths: false }).crawl("/");
+        await api[type]();
       },
       { timeout: 1000 }
     );

--- a/__tests__/symlinks.test.ts
+++ b/__tests__/symlinks.test.ts
@@ -107,10 +107,20 @@ const fsWithRecursiveRelativeSymlinks = {
   },
 };
 
+const fsWithSymlinkInRootDir = {
+  "/usr/lib": {
+    "file-1": "file contents",
+  },
+  "/lib": mock.symlink({
+    path: "/usr/lib",
+  }),
+};
+
 const mockFs = {
   ...fsWithRelativeSymlinks,
   ...fsWithRecursiveSymlinks,
   ...fsWithRecursiveRelativeSymlinks,
+  ...fsWithSymlinkInRootDir,
 
   "/sym/linked": {
     "file-1": "file contents",
@@ -363,6 +373,19 @@ for (const type of apiTypes) {
       const files = await api[type]();
       t.expect(files).toHaveLength(0);
     });
+
+    test("doesn't hang when resolving symlinks in the root directory", async () => {
+        await new fdir()
+          .exclude((_1, _2) => {
+            // Avoid crawling recursively for better test runtime.
+            return true;
+          })
+          .withSymlinks({ resolvePaths: false })
+          .crawl("/")
+          .withPromise();
+      },
+      { timeout: 1000 }
+    );
   });
 }
 

--- a/src/api/walker.ts
+++ b/src/api/walker.ts
@@ -37,7 +37,7 @@ export class Walker<TOutput extends Output> {
 
     this.root = normalizePath(root, options);
     this.state = {
-      root: this.root.slice(0, -1),
+      root: this.root === "/" ? this.root : this.root.slice(0, -1),
       // Perf: we explicitly tell the compiler to optimize for String arrays
       paths: [""].slice(0, 0),
       groups: [],


### PR DESCRIPTION
Fixes #135.

The current behavior makes it so that when we're crawling `"/"` with some symlinks and `resolvePath: false`, `state.root` is an empty string in https://github.com/thecodrr/fdir/blob/e2d5c86fc924cd6aba8053615dd7b73001726f7d/src/api/functions/resolve-symlink.ts#L75, hence we get stuck in an infinite loop.

Tests pass locally both on Linux (WSL) and Windows.