### PR TITLE
Ensure callback is called only once

### DIFF
--- a/__tests__/fdir.test.ts
+++ b/__tests__/fdir.test.ts
@@ -54,7 +54,8 @@ for (const type of apiTypes) {
     const files = await api[type]();
     t.expect(files.every((file) => file.split("/").length <= 2)).toBe(true);
   });
-  -test(`[${type}] crawl multi depth directory with options`, async (t) => {
+
+  test(`[${type}] crawl multi depth directory with options`, async (t) => {
     const api = new fdir({
       maxDepth: 1,
     }).crawl("node_modules");

--- a/src/api/functions/walk-directory.ts
+++ b/src/api/functions/walk-directory.ts
@@ -18,11 +18,12 @@ const walkAsync: WalkDirectoryFunction = (
   currentDepth,
   callback
 ) => {
-  if (currentDepth < 0) return state.queue.dequeue(null, state);
+  state.queue.enqueue();
+
+  if (currentDepth <= 0) return state.queue.dequeue(null, state);
 
   state.visited.push(crawlPath);
   state.counts.directories++;
-  state.queue.enqueue();
 
   // Perf: Node >= 10 introduced withFileTypes that helps us
   // skip an extra fs.stat call.
@@ -40,7 +41,7 @@ const walkSync: WalkDirectoryFunction = (
   currentDepth,
   callback
 ) => {
-  if (currentDepth < 0) return;
+  if (currentDepth <= 0) return;
   state.visited.push(crawlPath);
   state.counts.directories++;
 

--- a/src/api/queue.ts
+++ b/src/api/queue.ts
@@ -7,14 +7,21 @@ type OnQueueEmptyCallback = (error: Error | null, output: WalkerState) => void;
  * as soon as it completes. When the counter hits 0, it calls onQueueEmpty.
  */
 export class Queue {
-  private count: number = 0;
-  constructor(private readonly onQueueEmpty: OnQueueEmptyCallback) {}
+  count: number = 0;
+  constructor(private onQueueEmpty?: OnQueueEmptyCallback) {}
 
   enqueue() {
     this.count++;
+    return this.count;
   }
 
   dequeue(error: Error | null, output: WalkerState) {
-    if (--this.count <= 0 || error) this.onQueueEmpty(error, output);
+    if (this.onQueueEmpty && (--this.count <= 0 || error)) {
+      this.onQueueEmpty(error, output);
+      if (error) {
+        output.controller.abort();
+        this.onQueueEmpty = undefined;
+      }
+    }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,6 +32,7 @@ export type WalkerState = {
   counts: Counts;
   options: Options;
   queue: Queue;
+  controller: AbortController;
 
   symlinks: Map<string, string>;
   visited: string[];


### PR DESCRIPTION
Fixes #143 

This PR fixes multiple issues with the `queue/enqueue` logic ensuring:

- `onQueueEmpty` is called only once
- The crawler aborts on error (before it kept crawling which was pointless)

Another change I had to make was how the crawler always returned results `maxDepth + 1` deep. This might break some things (but not really sure since all tests pass).

cc @SuperchupuDev can you test this out with `tinyglobby` and let me know if something breaks? 