### PR TITLE
fix: do not stop crawling at `currentDepth` 0

### DIFF
--- a/__tests__/fdir.test.ts
+++ b/__tests__/fdir.test.ts
@@ -52,17 +52,24 @@ for (const type of apiTypes) {
       includeBasePath: true,
     }).crawl("node_modules");
     const files = await api[type]();
-    t.expect(files.every((file) => file.split("/").length <= 2)).toBe(true);
+    t.expect(files).not.toHaveLength(0);
+    t.expect(files.every((file) => file.split(path.sep).length === 2)).toBe(
+      true
+    );
   });
 
   test(`[${type}] crawl multi depth directory with options`, async (t) => {
     const api = new fdir({
       maxDepth: 1,
+      includeBasePath: true,
     }).crawl("node_modules");
     const files = await api[type]();
-    t.expect(
-      files.every((file) => file.split(path.sep).length <= 3)
-    ).toBeTruthy();
+    t.expect(files.some((file) => file.split(path.sep).length === 3)).toBe(
+      true
+    );
+    t.expect(files.every((file) => file.split(path.sep).length <= 3)).toBe(
+      true
+    );
   });
 
   test(`[${type}] crawl multi depth directory`, async (t) => {

--- a/src/api/functions/walk-directory.ts
+++ b/src/api/functions/walk-directory.ts
@@ -20,7 +20,7 @@ const walkAsync: WalkDirectoryFunction = (
 ) => {
   state.queue.enqueue();
 
-  if (currentDepth <= 0) return state.queue.dequeue(null, state);
+  if (currentDepth < 0) return state.queue.dequeue(null, state);
 
   state.visited.push(crawlPath);
   state.counts.directories++;
@@ -41,7 +41,7 @@ const walkSync: WalkDirectoryFunction = (
   currentDepth,
   callback
 ) => {
-  if (currentDepth <= 0) return;
+  if (currentDepth < 0) return;
   state.visited.push(crawlPath);
   state.counts.directories++;
 


### PR DESCRIPTION
fixes #148, it looks like the depth tests only tested against an upper bound and not a lower one, and as such i've updated them