### PR TITLE
perf: use `slice` instead of `replace` when joining path

### DIFF
--- a/src/api/functions/join-path.ts
+++ b/src/api/functions/join-path.ts
@@ -9,7 +9,7 @@ export function joinPathWithBasePath(filename: string, directoryPath: string) {
 function joinPathWithRelativePath(root: string, options: Options) {
   return function (filename: string, directoryPath: string) {
     const sameRoot = directoryPath.startsWith(root);
-    if (sameRoot) return directoryPath.replace(root, "") + filename;
+    if (sameRoot) return directoryPath.slice(root.length) + filename;
     else
       return (
         convertSlashes(relative(root, directoryPath), options.pathSeparator) +


### PR DESCRIPTION
Potential improvement found while working on #151. Tested with the following script:
```js
const path = "/some/very/long/path/to/a/directory";
const root = "/some/very/long/path/";

console.time("slice");
for (let i = 0; i < 1_000_000; i++) {
  const result = path.slice(root.length);
}
console.timeEnd("slice");

console.time("replace");
for (let i = 0; i < 1_000_000; i++) {
  const result = path.replace(root, "");
}
console.timeEnd("replace");
```

```
slice: 5.921ms
replace: 24.304ms
```