### PR TITLE
Drop AbortController as it breaks fdir on Node v14

### DIFF
--- a/__tests__/fdir.test.ts
+++ b/__tests__/fdir.test.ts
@@ -380,22 +380,22 @@ for (const type of apiTypes) {
   });
 }
 
-test(`[async] crawl directory & use abort signal to abort`, async (t) => {
-  // AbortController is not present on Node v14
-  if (!("AbortController" in globalThis)) return;
-
-  const totalFiles = new fdir().onlyCounts().crawl("node_modules").sync();
-  const abortController = new AbortController();
-  const api = new fdir()
-    .withAbortSignal(abortController.signal)
-    .filter((p) => {
-      if (p.endsWith(".js")) abortController.abort();
-      return true;
-    })
-    .crawl("node_modules");
-  const files = await api.withPromise();
-  t.expect(files.length).toBeLessThan(totalFiles.files);
-});
+// AbortController is not present on Node v14
+if ("AbortController" in globalThis) {
+  test(`[async] crawl directory & use abort signal to abort`, async (t) => {
+    const totalFiles = new fdir().onlyCounts().crawl("node_modules").sync();
+    const abortController = new AbortController();
+    const api = new fdir()
+      .withAbortSignal(abortController.signal)
+      .filter((p) => {
+        if (p.endsWith(".js")) abortController.abort();
+        return true;
+      })
+      .crawl("node_modules");
+    const files = await api.withPromise();
+    t.expect(files.length).toBeLessThan(totalFiles.files);
+  });
+}
 
 test(`paths should never start with ./`, async (t) => {
   const apis = [

--- a/src/api/aborter.ts
+++ b/src/api/aborter.ts
@@ -1,0 +1,10 @@
+/**
+ * AbortController is not supported on Node 14 so we use this until we can drop
+ * support for Node 14.
+ */
+export class Aborter {
+  aborted = false;
+  abort() {
+    this.aborted = true;
+  }
+}

--- a/src/api/walker.ts
+++ b/src/api/walker.ts
@@ -13,6 +13,7 @@ import { Queue } from "./queue";
 import { Dirent } from "fs";
 import { Output } from "../types";
 import { Counter } from "./counter";
+import { Aborter } from "./aborter";
 
 export class Walker<TOutput extends Output> {
   private readonly root: string;
@@ -48,7 +49,7 @@ export class Walker<TOutput extends Output> {
       ),
       symlinks: new Map(),
       visited: [""].slice(0, 0),
-      controller: new AbortController(),
+      controller: new Aborter(),
     };
 
     /*
@@ -94,7 +95,7 @@ export class Walker<TOutput extends Output> {
     } = this.state;
 
     if (
-      controller.signal.aborted ||
+      controller.aborted ||
       (signal && signal.aborted) ||
       (maxFiles && paths.length > maxFiles)
     )

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -12,7 +12,7 @@ import {
 } from "../types";
 import { APIBuilder } from "./api-builder";
 import type picomatch from "picomatch";
-import type { Matcher, PicomatchOptions } from "picomatch";
+import type { Matcher } from "picomatch";
 
 var pm: typeof picomatch | null = null;
 /* c8 ignore next 6 */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import { Aborter } from "./api/aborter";
 import { Queue } from "./api/queue";
 
 export type Counts = {
@@ -32,7 +33,7 @@ export type WalkerState = {
   counts: Counts;
   options: Options;
   queue: Queue;
-  controller: AbortController;
+  controller: Aborter;
 
   symlinks: Map<string, string>;
   visited: string[];


### PR DESCRIPTION
This is only a workaround until we can drop support for Node v14. Since AbortController is not exposed anywhere, we can replace it with a custom implementation.