### PR TITLE
feat: add `withIterator`

### DIFF
--- a/__tests__/utils.ts
+++ b/__tests__/utils.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
 export type APITypes = (typeof apiTypes)[number];
-export const apiTypes = ["withPromise", "sync"] as const;
+export const apiTypes = ["withPromise", "sync", "withIterator"] as const;
 
 export function root() {
   return process.platform === "win32" ? process.cwd().split(path.sep)[0] : "/";

--- a/src/api/functions/group-files.ts
+++ b/src/api/functions/group-files.ts
@@ -3,15 +3,17 @@ import { Group, Options } from "../../types";
 export type GroupFilesFunction = (
   groups: Group[],
   directory: string,
-  files: string[]
+  files: string[],
+  pushGroup: (group: Group, arr: Group[]) => void
 ) => void;
 
 const groupFiles: GroupFilesFunction = (
   groups: Group[],
   directory: string,
-  files: string[]
+  files: string[],
+  pushGroup
 ) => {
-  groups.push({ directory, files, dir: directory });
+  pushGroup({ directory, files, dir: directory }, groups);
 };
 
 const empty: GroupFilesFunction = () => {};

--- a/src/api/functions/push-directory.ts
+++ b/src/api/functions/push-directory.ts
@@ -3,38 +3,44 @@ import { FilterPredicate, Options } from "../../types";
 export type PushDirectoryFunction = (
   directoryPath: string,
   paths: string[],
+  pushPath: (path: string, arr: string[]) => void,
   filters?: FilterPredicate[]
 ) => void;
 
 function pushDirectoryWithRelativePath(root: string): PushDirectoryFunction {
-  return function (directoryPath, paths) {
-    paths.push(directoryPath.substring(root.length) || ".");
+  return function (directoryPath, paths, pushPath) {
+    pushPath(directoryPath.substring(root.length) || ".", paths);
   };
 }
 
 function pushDirectoryFilterWithRelativePath(
   root: string
 ): PushDirectoryFunction {
-  return function (directoryPath, paths, filters) {
+  return function (directoryPath, paths, pushPath, filters) {
     const relativePath = directoryPath.substring(root.length) || ".";
     if (filters!.every((filter) => filter(relativePath, true))) {
-      paths.push(relativePath);
+      pushPath(relativePath, paths);
     }
   };
 }
 
-const pushDirectory: PushDirectoryFunction = (directoryPath, paths) => {
-  paths.push(directoryPath || ".");
+const pushDirectory: PushDirectoryFunction = (
+  directoryPath,
+  paths,
+  pushPath
+) => {
+  pushPath(directoryPath || ".", paths);
 };
 
 const pushDirectoryFilter: PushDirectoryFunction = (
   directoryPath,
   paths,
+  pushPath,
   filters
 ) => {
   const path = directoryPath || ".";
   if (filters!.every((filter) => filter(path, true))) {
-    paths.push(path);
+    pushPath(path, paths);
   }
 };
 

--- a/src/api/functions/push-file.ts
+++ b/src/api/functions/push-file.ts
@@ -3,6 +3,7 @@ import { FilterPredicate, Options, Counts } from "../../types";
 export type PushFileFunction = (
   directoryPath: string,
   paths: string[],
+  pushPath: (path: string, arr: string[]) => void,
   counts: Counts,
   filters?: FilterPredicate[]
 ) => void;
@@ -10,6 +11,7 @@ export type PushFileFunction = (
 const pushFileFilterAndCount: PushFileFunction = (
   filename,
   _paths,
+  _pushPath,
   counts,
   filters
 ) => {
@@ -19,23 +21,26 @@ const pushFileFilterAndCount: PushFileFunction = (
 const pushFileFilter: PushFileFunction = (
   filename,
   paths,
+  pushPath,
   _counts,
   filters
 ) => {
-  if (filters!.every((filter) => filter(filename, false))) paths.push(filename);
+  if (filters!.every((filter) => filter(filename, false)))
+    pushPath(filename, paths);
 };
 
 const pushFileCount: PushFileFunction = (
   _filename,
   _paths,
+  _pushPath,
   counts,
   _filters
 ) => {
   counts.files++;
 };
 
-const pushFile: PushFileFunction = (filename, paths) => {
-  paths.push(filename);
+const pushFile: PushFileFunction = (filename, paths, pushPath) => {
+  pushPath(filename, paths);
 };
 
 const empty: PushFileFunction = () => {};

--- a/src/api/iterator.ts
+++ b/src/api/iterator.ts
@@ -2,14 +2,12 @@ import { Options, IterableOutput } from "../types";
 import { Walker } from "./walker";
 
 class WalkerIterator<TOutput extends IterableOutput> {
-  #next: Promise<TOutput | null>;
-  #resolver: (value: TOutput[number] | null) => void;
+  #resolver?: (result: TOutput[number]) => void;
   #walker: Walker<TOutput>;
   #currentGroup?: string[];
+  #queue: TOutput[number][] = [];
 
   public constructor(root: string, options: Options) {
-    this.#resolver = () => {};
-    this.#next = this.#createNext();
     const pushPath = options.group ? this.#pushPath : this.#pushResult;
     this.#walker = new Walker<TOutput>(
       root,
@@ -28,48 +26,37 @@ class WalkerIterator<TOutput extends IterableOutput> {
   };
 
   #pushResult = async (result: TOutput[number]) => {
-    this.#resolver(result);
-    this.#next = this.#createNext(this.#next);
+    this.#queue.push(result);
+    if (this.#resolver) {
+      const resolver = this.#resolver;
+      this.#resolver = undefined;
+      resolver(result);
+    }
   };
 
   #onComplete = () => {
     this.#currentGroup = undefined;
-    this.#resolver(null);
+    this.#complete = true;
   };
 
-  async #createNext(prev?: Promise<TOutput | null>): Promise<TOutput | null> {
-    const next = new Promise<TOutput[number] | null>((resolve) => {
-      this.#resolver = resolve;
-    });
-    if (prev) {
-      const prevResult = await prev;
-      const nextResult = await next;
-      if (prevResult === null || nextResult === null) {
-        return null;
-      }
-      return [...prevResult, nextResult] as TOutput | null;
-    } else {
-      const nextResult = await next;
-      return nextResult === null ? nextResult : ([nextResult] as TOutput);
-    }
-  }
-
   async *[Symbol.asyncIterator]() {
-    let promise = this.#next;
     this.#walker.start();
 
-    let finished = false;
+    while (true) {
+      yield* this.#queue;
+      this.#queue = [];
 
-    while (!finished) {
-      const result = await promise;
-      promise = this.#next;
-      if (result === null) {
-        finished = true;
-      } else {
-        yield* result;
+      if (this.#complete) {
+        return;
       }
+
+      await new Promise<TOutput[number]>((resolve) => {
+        this.#resolver = resolve;
+      });
     }
   }
+
+  #complete: boolean = false;
 }
 
 export function iterator<TOutput extends IterableOutput>(

--- a/src/api/iterator.ts
+++ b/src/api/iterator.ts
@@ -1,0 +1,70 @@
+import { Options, IterableOutput } from "../types";
+import { Walker } from "./walker";
+
+class WalkerIterator<TOutput extends IterableOutput> {
+  #next: Promise<TOutput[number] | null>;
+  #resolver: (value: TOutput[number] | null) => void;
+  #walker: Walker<TOutput>;
+  #currentGroup?: string[];
+
+  public constructor(root: string, options: Options) {
+    this.#resolver = () => {};
+    this.#next = this.#createNext();
+    const pushPath = options.group ? this.#pushPath : this.#pushResult;
+    this.#walker = new Walker<TOutput>(
+      root,
+      options,
+      this.#onComplete,
+      pushPath,
+      this.#pushResult
+    );
+  }
+
+  #pushPath = (path: string, arr: string[]) => {
+    if (arr !== this.#currentGroup) {
+      this.#currentGroup = arr;
+    }
+    arr.push(path);
+  };
+
+  #pushResult = async (result: TOutput[number]) => {
+    this.#resolver(result);
+    this.#next = this.#createNext();
+  };
+
+  #onComplete = () => {
+    this.#currentGroup = undefined;
+    this.#resolver(null);
+  };
+
+  #createNext(): Promise<TOutput[number] | null> {
+    return new Promise((resolve) => {
+      this.#resolver = resolve;
+    });
+  }
+
+  async *[Symbol.asyncIterator]() {
+    let promise = this.#next;
+    this.#walker.start();
+
+    let finished = false;
+
+    while (!finished) {
+      const result = await promise;
+      promise = this.#next;
+      if (result === null) {
+        finished = true;
+      } else {
+        yield result;
+      }
+    }
+  }
+}
+
+export function iterator<TOutput extends IterableOutput>(
+  root: string,
+  options: Options
+): AsyncIterable<TOutput[number]> {
+  const iterator = new WalkerIterator<TOutput>(root, options);
+  return iterator;
+}

--- a/src/api/walker.ts
+++ b/src/api/walker.ts
@@ -1,6 +1,6 @@
 import { basename, dirname } from "path";
 import { isRootDirectory, normalizePath } from "../utils";
-import { ResultCallback, WalkerState, Options } from "../types";
+import { ResultCallback, WalkerState, Options, Group } from "../types";
 import * as joinPath from "./functions/join-path";
 import * as pushDirectory from "./functions/push-directory";
 import * as pushFile from "./functions/push-file";
@@ -26,11 +26,15 @@ export class Walker<TOutput extends Output> {
   private readonly resolveSymlink: resolveSymlink.ResolveSymlinkFunction | null;
   private readonly walkDirectory: walkDirectory.WalkDirectoryFunction;
   private readonly callbackInvoker: invokeCallback.InvokeCallbackFunction<TOutput>;
+  private readonly pushPath: (path: string, arr: string[]) => void;
+  private readonly pushGroup: (group: Group, arr: Group[]) => void;
 
   constructor(
     root: string,
     options: Options,
-    callback?: ResultCallback<TOutput>
+    callback?: ResultCallback<TOutput>,
+    pushPath?: (path: string, arr: string[]) => void,
+    pushGroup?: (group: Group, arr: Group[]) => void
   ) {
     this.isSynchronous = !callback;
     this.callbackInvoker = invokeCallback.build(options, this.isSynchronous);
@@ -63,10 +67,25 @@ export class Walker<TOutput extends Output> {
     this.groupFiles = groupFiles.build(options);
     this.resolveSymlink = resolveSymlink.build(options, this.isSynchronous);
     this.walkDirectory = walkDirectory.build(this.isSynchronous);
+    this.pushPath =
+      pushPath ??
+      ((p, arr) => {
+        arr.push(p);
+      });
+    this.pushGroup =
+      pushGroup ??
+      ((group, arr) => {
+        arr.push(group);
+      });
   }
 
   start(): TOutput | null {
-    this.pushDirectory(this.root, this.state.paths, this.state.options.filters);
+    this.pushDirectory(
+      this.root,
+      this.state.paths,
+      this.pushPath,
+      this.state.options.filters
+    );
     this.walkDirectory(
       this.state,
       this.root,
@@ -109,7 +128,13 @@ export class Walker<TOutput extends Output> {
         (entry.isSymbolicLink() && !resolveSymlinks && !excludeSymlinks)
       ) {
         const filename = this.joinPath(entry.name, directoryPath);
-        this.pushFile(filename, files, this.state.counts, filters);
+        this.pushFile(
+          filename,
+          files,
+          this.pushPath,
+          this.state.counts,
+          filters
+        );
       } else if (entry.isDirectory()) {
         let path = joinPath.joinDirectoryPath(
           entry.name,
@@ -117,7 +142,7 @@ export class Walker<TOutput extends Output> {
           this.state.options.pathSeparator
         );
         if (exclude && exclude(entry.name, path)) continue;
-        this.pushDirectory(path, paths, filters);
+        this.pushDirectory(path, files, this.pushPath, filters);
         this.walkDirectory(this.state, path, path, depth - 1, this.walk);
       } else if (this.resolveSymlink && entry.isSymbolicLink()) {
         let path = joinPath.joinPathWithBasePath(entry.name, directoryPath);
@@ -148,12 +173,18 @@ export class Walker<TOutput extends Output> {
               this.state.options
             );
             resolvedPath = this.joinPath(filename, directoryPath);
-            this.pushFile(resolvedPath, files, this.state.counts, filters);
+            this.pushFile(
+              resolvedPath,
+              files,
+              this.pushPath,
+              this.state.counts,
+              filters
+            );
           }
         });
       }
     }
 
-    this.groupFiles(this.state.groups, directoryPath, files);
+    this.groupFiles(this.state.groups, directoryPath, files, this.pushGroup);
   };
 }

--- a/src/builder/api-builder.ts
+++ b/src/builder/api-builder.ts
@@ -1,6 +1,7 @@
 import { callback, promise } from "../api/async";
 import { sync } from "../api/sync";
-import { Options, Output, ResultCallback } from "../types";
+import { iterator } from "../api/iterator";
+import { Options, Output, ResultCallback, IterableOutput } from "../types";
 
 export class APIBuilder<TReturnType extends Output> {
   constructor(
@@ -18,5 +19,12 @@ export class APIBuilder<TReturnType extends Output> {
 
   sync(): TReturnType {
     return sync(this.root, this.options);
+  }
+
+  withIterator(): TReturnType extends IterableOutput
+    ? AsyncIterable<TReturnType[number]>
+    : never {
+    // TODO (43081j): get rid of this awful `never`
+    return iterator(this.root, this.options) as never;
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export type OnlyCountsOutput = Counts;
 export type PathsOutput = string[];
 
 export type Output = OnlyCountsOutput | PathsOutput | GroupOutput;
+export type IterableOutput = PathsOutput | GroupOutput;
 
 export type WalkerState = {
   root: string;


### PR DESCRIPTION
This is just a draft of what I could come up with.

it isn't a true iterator of paths since we still read each directory as a batch under the hood. but it does mean we're only ever holding at most whats in one directory in memory

we could one day follow up on this by switching to `opendir` and reading entries one by one

if this implementation seems of any interest, let me know and i can publish as non-draft and review with you

@thecodrr @SuperchupuDev 