### PR TITLE
fix: support `@types/picomatch` v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/glob": "^8.1.0",
         "@types/mock-fs": "^4.13.4",
         "@types/node": "^20.9.4",
-        "@types/picomatch": "^3.0.0",
+        "@types/picomatch": "^4.0.0",
         "@types/tap": "^15.0.11",
         "@vitest/coverage-v8": "^0.34.6",
         "all-files-in-tree": "^1.1.2",
@@ -1150,10 +1150,11 @@
       }
     },
     "node_modules/@types/picomatch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-3.0.0.tgz",
-      "integrity": "sha512-iX/Qwk9vU17N/5Q7QrV46wzciloTdCqTRt6z8A7uFFADM2+Sy5oQh9ldZhAiTXH+l0sM/EkXatEhJIs8FUyOBQ==",
-      "dev": true
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-4.0.0.tgz",
+      "integrity": "sha512-J1Bng+wlyEERWSgJQU1Pi0HObCLVcr994xT/M+1wcl/yNRTGBupsCxthgkdYG+GCOMaQH7iSVUY3LJVBBqG7MQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/glob": "^8.1.0",
     "@types/mock-fs": "^4.13.4",
     "@types/node": "^20.9.4",
-    "@types/picomatch": "^3.0.0",
+    "@types/picomatch": "^4.0.0",
     "@types/tap": "^15.0.11",
     "@vitest/coverage-v8": "^0.34.6",
     "all-files-in-tree": "^1.1.2",

--- a/src/builder/index.ts
+++ b/src/builder/index.ts
@@ -8,18 +8,18 @@ import {
   FilterPredicate,
   ExcludePredicate,
   GlobFunction,
+  GlobMatcher,
   GlobParams,
 } from "../types";
 import { APIBuilder } from "./api-builder";
 import type picomatch from "picomatch";
-import type { Matcher } from "picomatch";
 
-var pm: typeof picomatch | null = null;
+let pm: typeof picomatch | null = null;
 /* c8 ignore next 6 */
 try {
   require.resolve("picomatch");
   pm = require("picomatch");
-} catch (_e) {
+} catch {
   // do nothing
 }
 
@@ -27,7 +27,7 @@ export class Builder<
   TReturnType extends Output = PathsOutput,
   TGlobFunction = typeof picomatch,
 > {
-  private readonly globCache: Record<string, Matcher> = {};
+  private readonly globCache: Record<string, GlobMatcher> = {};
   private options: Options<TGlobFunction> = {
     maxDepth: Infinity,
     suppressErrors: true,


### PR DESCRIPTION
`@types/picomatch` v4 makes `Matcher` have an optional second argument. if set to `true`, it makes the function return some object and not a string. This breaks `fdir`'s types. To fix this, I replaced it with the already used `GlobMatcher` type that's identical to `Matcher` except it doesn't require a second argument (this makes sense to use since, if the second argument was used, fdir would break at runtime since it doesn't expect an object)

Ideally #147 should be merged first to avoid causing merge conflicts on that pr :pray:

For prior work see SuperchupuDev/tinyglobby@f2419f8

Also makes `picomatch` importing have modern syntax. It doesn't break any compatibility, everything changed works starting from node 10. And fdir supports node 12 and up (manually checked)