### PR TITLE
fix: use `||` instead of `??` for node 12 compat

### DIFF
--- a/src/api/walker.ts
+++ b/src/api/walker.ts
@@ -51,7 +51,7 @@ export class Walker<TOutput extends Output> {
       symlinks: new Map(),
       visited: [""].slice(0, 0),
       controller: new Aborter(),
-      fs: options.fs ?? nativeFs,
+      fs: options.fs || nativeFs,
     };
 
     /*


### PR DESCRIPTION
#136 used the `??` operator (probably on accident) which would break node compat again :sweat_smile: tiny change but important