### PR TITLE
Migrate away from mock-fs

### DIFF
--- a/__tests__/mock-fs.ts
+++ b/__tests__/mock-fs.ts
@@ -1,6 +1,7 @@
 import Directory from "mock-fs/lib/directory";
 import FileSystem from "mock-fs/lib/filesystem";
 import SymbolicLink from "mock-fs/lib/symlink";
+import File from "mock-fs/lib/file";
 import { resolve, sep } from "path";
 import { root } from "./utils";
 import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "fs/promises";
@@ -60,10 +61,7 @@ export class MockFS {
       if (typeof item === "function") {
         const unknownItem = item();
         if (unknownItem instanceof File) {
-          await writeFile(
-            parentPath,
-            new Uint8Array(await unknownItem.arrayBuffer())
-          );
+          await writeFile(parentPath, unknownItem.getContent());
         } else if (unknownItem instanceof SymbolicLink) {
           const targetPath = resolvePath(
             this.root,

--- a/__tests__/mock-fs.ts
+++ b/__tests__/mock-fs.ts
@@ -1,0 +1,102 @@
+import Directory from "mock-fs/lib/directory";
+import FileSystem from "mock-fs/lib/filesystem";
+import SymbolicLink from "mock-fs/lib/symlink";
+import { resolve, sep } from "path";
+import { root } from "./utils";
+import { mkdir, mkdtemp, rm, stat, symlink, writeFile } from "fs/promises";
+
+export class MockFS {
+  root: string;
+  constructor(private readonly filesystem: FileSystem.DirectoryItems) {}
+
+  async cleanup() {
+    await rm(this.root, { recursive: true, force: true });
+  }
+
+  normalize(paths: string[]) {
+    return paths.map((p) => resolvePath(this.root, this.root, p));
+  }
+
+  resolve(path: string) {
+    return resolvePath(this.root, this.root, path);
+  }
+
+  async init() {
+    this.root = await mkdtemp("fdir");
+    const { symlinks } = await this.createFilesystem(
+      this.root,
+      this.filesystem
+    );
+    for (const { path, targetPath } of symlinks) {
+      if (!targetPath.includes(this.root))
+        throw new Error(
+          "Cannot recurse above the temp directory: " + targetPath
+        );
+
+      const isDirectory = await (async () => {
+        try {
+          return (await stat(targetPath)).isDirectory();
+        } catch {
+          return false;
+        }
+      })();
+      await symlink(targetPath, path, isDirectory ? "dir" : "file");
+    }
+  }
+
+  private async createFilesystem(
+    root: string,
+    filesystem: FileSystem.DirectoryItems
+  ) {
+    await mkdir(root, { recursive: true });
+    let symlinks: { path: string; targetPath: string }[] = [];
+    for (const name in filesystem) {
+      const item = filesystem[name];
+      const parentPath = resolvePath(this.root, root, name);
+      if (!parentPath.includes(this.root))
+        throw new Error(
+          "Cannot recurse above the temp directory: " + parentPath
+        );
+      if (typeof item === "function") {
+        const unknownItem = item();
+        if (unknownItem instanceof File) {
+          await writeFile(
+            parentPath,
+            new Uint8Array(await unknownItem.arrayBuffer())
+          );
+        } else if (unknownItem instanceof SymbolicLink) {
+          const targetPath = resolvePath(
+            this.root,
+            root,
+            unknownItem.getPath()
+          );
+          symlinks.push({
+            path: parentPath,
+            targetPath,
+          });
+        } else if (unknownItem instanceof Directory) {
+          throw new Error("Not implemented.");
+        }
+      } else if (typeof item === "string" || Buffer.isBuffer(item)) {
+        await writeFile(parentPath, item);
+      } else {
+        symlinks = [
+          ...symlinks,
+          ...(await this.createFilesystem(parentPath, item)).symlinks,
+        ];
+      }
+    }
+    return { symlinks };
+  }
+}
+
+function resolvePath(rootPath: string, relativeRoot: string, path: string) {
+  const startsWithRoot = path.startsWith(root());
+  const endsWithPathSeparator = path.endsWith(sep);
+  if (startsWithRoot)
+    return (
+      resolve(rootPath, path.replace(root(), "")) +
+      (endsWithPathSeparator ? sep : "")
+    );
+  return resolve(relativeRoot, path) + (endsWithPathSeparator ? sep : "");
+}

--- a/src/api/functions/join-directory-path.ts
+++ b/src/api/functions/join-directory-path.ts
@@ -1,0 +1,51 @@
+import { relative } from "path";
+import { Options, PathSeparator } from "../../types";
+import { convertSlashes } from "../../utils";
+
+function joinDirectoryPathWithRelativePath(root: string, options: Options) {
+  return function (
+    dirname: string,
+    parentPath: string,
+    separator: PathSeparator
+  ) {
+    const sameRoot = parentPath.startsWith(root);
+    if (sameRoot)
+      return joinDirectoryPath(
+        dirname,
+        parentPath.slice(root.length),
+        separator
+      );
+    else
+      return joinDirectoryPath(
+        dirname,
+        convertSlashes(relative(root, parentPath), separator) + separator,
+        separator
+      );
+  };
+}
+
+export function joinDirectoryPath(
+  dirname: string,
+  parentPath: string,
+  separator: PathSeparator
+) {
+  if (!dirname) return parentPath || ".";
+  return parentPath + dirname + separator;
+}
+
+export type JoinDirectoryPathFunction = (
+  dirname: string,
+  parentPath: string,
+  separator: PathSeparator
+) => string;
+
+export function build(
+  root: string,
+  options: Options
+): JoinDirectoryPathFunction {
+  const { relativePaths } = options;
+
+  return relativePaths && root
+    ? joinDirectoryPathWithRelativePath(root, options)
+    : joinDirectoryPath;
+}

--- a/src/api/functions/join-path.ts
+++ b/src/api/functions/join-path.ts
@@ -1,5 +1,5 @@
 import { relative } from "path";
-import { Options, PathSeparator } from "../../types";
+import { Options } from "../../types";
 import { convertSlashes } from "../../utils";
 
 export function joinPathWithBasePath(filename: string, directoryPath: string) {
@@ -21,14 +21,6 @@ function joinPathWithRelativePath(root: string, options: Options) {
 
 function joinPath(filename: string) {
   return filename;
-}
-
-export function joinDirectoryPath(
-  filename: string,
-  directoryPath: string,
-  separator: PathSeparator
-) {
-  return directoryPath + filename + separator;
 }
 
 export type JoinPathFunction = (

--- a/src/api/functions/push-directory.ts
+++ b/src/api/functions/push-directory.ts
@@ -6,25 +6,8 @@ export type PushDirectoryFunction = (
   filters?: FilterPredicate[]
 ) => void;
 
-function pushDirectoryWithRelativePath(root: string): PushDirectoryFunction {
-  return function (directoryPath, paths) {
-    paths.push(directoryPath.substring(root.length) || ".");
-  };
-}
-
-function pushDirectoryFilterWithRelativePath(
-  root: string
-): PushDirectoryFunction {
-  return function (directoryPath, paths, filters) {
-    const relativePath = directoryPath.substring(root.length) || ".";
-    if (filters!.every((filter) => filter(relativePath, true))) {
-      paths.push(relativePath);
-    }
-  };
-}
-
 const pushDirectory: PushDirectoryFunction = (directoryPath, paths) => {
-  paths.push(directoryPath || ".");
+  paths.push(directoryPath);
 };
 
 const pushDirectoryFilter: PushDirectoryFunction = (
@@ -32,21 +15,14 @@ const pushDirectoryFilter: PushDirectoryFunction = (
   paths,
   filters
 ) => {
-  const path = directoryPath || ".";
-  if (filters!.every((filter) => filter(path, true))) {
-    paths.push(path);
-  }
+  if (filters!.every((filter) => filter(directoryPath, true)))
+    paths.push(directoryPath);
 };
 
 const empty: PushDirectoryFunction = () => {};
 
-export function build(root: string, options: Options): PushDirectoryFunction {
-  const { includeDirs, filters, relativePaths } = options;
+export function build(options: Options): PushDirectoryFunction {
+  const { includeDirs, filters } = options;
   if (!includeDirs) return empty;
-
-  if (relativePaths)
-    return filters && filters.length
-      ? pushDirectoryFilterWithRelativePath(root)
-      : pushDirectoryWithRelativePath(root);
   return filters && filters.length ? pushDirectoryFilter : pushDirectory;
 }


### PR DESCRIPTION
We were using `mock-fs` for testing symlinks and some other things. Unfortunately, `mock-fs` does not support `opendir` API which will be used by the iterator API we plan on adding in the future. This PR migrates the symlink and other mock-fs dependent tests to use the actual filesystem instead. This has a number of advantages:

- mock-fs is no longer maintained and will probably be phased out as soon as Node.js removes support for `bindings`
- mock-fs does not always accurately represent how an actual filesystem works.

Since this PR changes how tests work, it should be tested on some real world cases as well.

cc @SuperchupuDev (would love if you can test this out with tinyglobby)